### PR TITLE
Fix Cleaner leak: replace anonymous ThreadFactory with static nested class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.asana</groupId>
     <artifactId>mysql-binlog-connector-java-asana-fork</artifactId>
-    <version>0.30.1</version>
+    <version>0.30.2</version>
 
     <name>mysql-binlog-connector-java</name>
     <description>MySQL Binary Log connector</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.asana</groupId>
     <artifactId>mysql-binlog-connector-java-asana-fork</artifactId>
-    <version>0.30.2</version>
+    <version>0.30.3</version>
 
     <name>mysql-binlog-connector-java</name>
     <description>MySQL Binary Log connector</description>

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -862,13 +862,8 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     private void spawnKeepAliveThread() {
         final String keepAliveThreadName = "blc-keepalive-" + hostname + ":" + port;
         final ExecutorService threadExecutor =
-            Executors.newSingleThreadExecutor(new ThreadFactory() {
-
-                @Override
-                public Thread newThread(Runnable runnable) {
-                    return newNamedThread(runnable, keepAliveThreadName);
-                }
-            });
+            Executors.newSingleThreadExecutor(
+                new KeepAliveThreadFactory(threadFactory, keepAliveThreadName));
         try {
             keepAliveThreadExecutorLock.lock();
             threadExecutor.submit(new Runnable() {
@@ -1326,17 +1321,22 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void terminateKeepAliveThread() {
+        ExecutorService localExecutor;
         try {
             keepAliveThreadExecutorLock.lock();
-            ExecutorService keepAliveThreadExecutor = this.keepAliveThreadExecutor;
-            if ( keepAliveThreadExecutor == null ) {
+            localExecutor = this.keepAliveThreadExecutor;
+            if ( localExecutor == null ) {
                 return;
             }
-            keepAliveThreadExecutor.shutdownNow();
+            localExecutor.shutdownNow();
+            // Belt-and-suspenders: null the field so BinaryLogClient no longer strongly
+            // holds the executor after disconnect, even if a future refactor reintroduces
+            // an outer capture in KeepAliveThreadFactory.
+            this.keepAliveThreadExecutor = null;
         } finally {
             keepAliveThreadExecutorLock.unlock();
         }
-        while (!awaitTerminationInterruptibly(keepAliveThreadExecutor,
+        while (!awaitTerminationInterruptibly(localExecutor,
             Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
             // ignore
         }
@@ -1436,6 +1436,33 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
 
         public void onDisconnect(BinaryLogClient client) { }
 
+    }
+
+    /**
+     * Static so it cannot capture {@code BinaryLogClient.this}. An anonymous or non-static inner
+     * class declared in instance context implicitly captures the enclosing instance via a synthetic
+     * {@code this$0} field (JLS §15.9.5), regardless of whether the body references instance
+     * members. The JDK Cleaner registered by {@code AutoShutdownDelegatedExecutorService} holds
+     * the {@code ThreadPoolExecutor}, which holds its {@code threadFactory}. If that factory
+     * transitively reaches the executor (the Cleaner's referent), the referent is never
+     * phantom-reachable and the Cleaner action never runs, leaking ~1.6 MB per
+     * {@code BinaryLogClient} lifecycle.
+     */
+    private static final class KeepAliveThreadFactory implements ThreadFactory {
+        private final ThreadFactory delegate;
+        private final String threadName;
+
+        KeepAliveThreadFactory(ThreadFactory delegate, String threadName) {
+            this.delegate = delegate;
+            this.threadName = threadName;
+        }
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = delegate == null ? new Thread(runnable) : delegate.newThread(runnable);
+            thread.setName(threadName);
+            return thread;
+        }
     }
 
 }

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -860,12 +860,13 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void spawnKeepAliveThread() {
+        final String keepAliveThreadName = "blc-keepalive-" + hostname + ":" + port;
         final ExecutorService threadExecutor =
             Executors.newSingleThreadExecutor(new ThreadFactory() {
 
                 @Override
                 public Thread newThread(Runnable runnable) {
-                    return newNamedThread(runnable, "blc-keepalive-" + hostname + ":" + port);
+                    return newNamedThread(runnable, keepAliveThreadName);
                 }
             });
         try {
@@ -1333,13 +1334,6 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 return;
             }
             localExecutor.shutdownNow();
-            // Null the field while holding the lock so the executor becomes unreachable from this
-            // BinaryLogClient instance. Without this, the JVM Cleaner's PhantomCleanableRef for
-            // the executor can never fire: the Cleaner's own activeList holds a strong reference
-            // to the cleanup action lambda, which captures ThreadPoolExecutor, whose threadFactory
-            // is a BinaryLogClient inner class that captures `this`, which holds keepAliveThreadExecutor
-            // — a cycle that prevents the executor from ever becoming phantom-reachable.
-            this.keepAliveThreadExecutor = null;
         } finally {
             keepAliveThreadExecutorLock.unlock();
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -1326,18 +1326,17 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void terminateKeepAliveThread() {
-        ExecutorService localExecutor;
         try {
             keepAliveThreadExecutorLock.lock();
-            localExecutor = this.keepAliveThreadExecutor;
-            if ( localExecutor == null ) {
+            ExecutorService keepAliveThreadExecutor = this.keepAliveThreadExecutor;
+            if ( keepAliveThreadExecutor == null ) {
                 return;
             }
-            localExecutor.shutdownNow();
+            keepAliveThreadExecutor.shutdownNow();
         } finally {
             keepAliveThreadExecutorLock.unlock();
         }
-        while (!awaitTerminationInterruptibly(localExecutor,
+        while (!awaitTerminationInterruptibly(keepAliveThreadExecutor,
             Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
             // ignore
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -860,10 +860,9 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void spawnKeepAliveThread() {
-        final String keepAliveThreadName = "blc-keepalive-" + hostname + ":" + port;
         final ExecutorService threadExecutor =
             Executors.newSingleThreadExecutor(
-                new KeepAliveThreadFactory(threadFactory, keepAliveThreadName));
+                new KeepAliveThreadFactory(threadFactory, "blc-keepalive-" + hostname + ":" + port));
         try {
             keepAliveThreadExecutorLock.lock();
             threadExecutor.submit(new Runnable() {

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -860,14 +860,10 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void spawnKeepAliveThread() {
+        final String keepAliveThreadName = "blc-keepalive-" + hostname + ":" + port;
         final ExecutorService threadExecutor =
-            Executors.newSingleThreadExecutor(new ThreadFactory() {
-
-                @Override
-                public Thread newThread(Runnable runnable) {
-                    return newNamedThread(runnable, "blc-keepalive-" + hostname + ":" + port);
-                }
-            });
+            Executors.newSingleThreadExecutor(
+                new KeepAliveThreadFactory(this.threadFactory, keepAliveThreadName));
         try {
             keepAliveThreadExecutorLock.lock();
             threadExecutor.submit(new Runnable() {

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -867,8 +867,8 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 public Thread newThread(Runnable runnable) {
                     return newNamedThread(runnable, "blc-keepalive-" + hostname + ":" + port);
                 }
-            });        
-	try {
+            });
+        try {
             keepAliveThreadExecutorLock.lock();
             threadExecutor.submit(new Runnable() {
                 @Override

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -861,9 +861,14 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
 
     private void spawnKeepAliveThread() {
         final ExecutorService threadExecutor =
-            Executors.newSingleThreadExecutor(
-                new KeepAliveThreadFactory(threadFactory, "blc-keepalive-" + hostname + ":" + port));
-        try {
+            Executors.newSingleThreadExecutor(new ThreadFactory() {
+
+                @Override
+                public Thread newThread(Runnable runnable) {
+                    return newNamedThread(runnable, "blc-keepalive-" + hostname + ":" + port);
+                }
+            });        
+	try {
             keepAliveThreadExecutorLock.lock();
             threadExecutor.submit(new Runnable() {
                 @Override

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -1321,22 +1321,17 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void terminateKeepAliveThread() {
-        ExecutorService localExecutor;
         try {
             keepAliveThreadExecutorLock.lock();
-            localExecutor = this.keepAliveThreadExecutor;
-            if ( localExecutor == null ) {
+            ExecutorService keepAliveThreadExecutor = this.keepAliveThreadExecutor;
+            if ( keepAliveThreadExecutor == null ) {
                 return;
             }
-            localExecutor.shutdownNow();
-            // Belt-and-suspenders: null the field so BinaryLogClient no longer strongly
-            // holds the executor after disconnect, even if a future refactor reintroduces
-            // an outer capture in KeepAliveThreadFactory.
-            this.keepAliveThreadExecutor = null;
+            keepAliveThreadExecutor.shutdownNow();
         } finally {
             keepAliveThreadExecutorLock.unlock();
         }
-        while (!awaitTerminationInterruptibly(localExecutor,
+        while (!awaitTerminationInterruptibly(keepAliveThreadExecutor,
             Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
             // ignore
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -1325,17 +1325,25 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void terminateKeepAliveThread() {
+        ExecutorService localExecutor;
         try {
             keepAliveThreadExecutorLock.lock();
-            ExecutorService keepAliveThreadExecutor = this.keepAliveThreadExecutor;
-            if ( keepAliveThreadExecutor == null ) {
+            localExecutor = this.keepAliveThreadExecutor;
+            if ( localExecutor == null ) {
                 return;
             }
-            keepAliveThreadExecutor.shutdownNow();
+            localExecutor.shutdownNow();
+            // Null the field while holding the lock so the executor becomes unreachable from this
+            // BinaryLogClient instance. Without this, the JVM Cleaner's PhantomCleanableRef for
+            // the executor can never fire: the Cleaner's own activeList holds a strong reference
+            // to the cleanup action lambda, which captures ThreadPoolExecutor, whose threadFactory
+            // is a BinaryLogClient inner class that captures `this`, which holds keepAliveThreadExecutor
+            // — a cycle that prevents the executor from ever becoming phantom-reachable.
+            this.keepAliveThreadExecutor = null;
         } finally {
             keepAliveThreadExecutorLock.unlock();
         }
-        while (!awaitTerminationInterruptibly(keepAliveThreadExecutor,
+        while (!awaitTerminationInterruptibly(localExecutor,
             Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
             // ignore
         }


### PR DESCRIPTION
## Context

Each `BinaryLogClient` lifecycle creates one `AutoShutdownDelegatedExecutorService` (via `Executors.newSingleThreadExecutor`) which registers a `PhantomCleanableRef` in the JVM Cleaner. Due to the bug below, these entries never get cleaned up — accumulating permanently per BLC lifecycle.

The leak rate is proportional to how frequently BLC instances are created and destroyed. With a single TVC writer, a BLC lifetime is typically bounded by `maxNumEntriesPopulated` (~0.1 lifecycles/minute). With multiple TVC writers or skip invalidation, `lastSeenHighest` advances faster, cache entries fill up sooner, and BLC lifecycles are much shorter — meaning the leak accumulates significantly faster.

See the Datadog notebook for heap dump analysis confirming the leak: https://app.datadoghq.com/notebook/14500642/binarylogclient-memory-leak

A heap dump shows ~100,000 stuck `PhantomCleanableRef`s pointing to `BinaryLogClient` instances:

<img width="836" height="885" alt="image" src="https://github.com/user-attachments/assets/36c437f1-1b12-4fee-895d-a0844db93fb2" />

## Problem

The [Java `Cleaner` docs](https://docs.oracle.com/javase/9/docs/api/java/lang/ref/Cleaner.html) explicitly state:

> *"An inner class, anonymous or not, must not be used because it implicitly contains a reference to the outer instance, preventing it from becoming phantom reachable."*

`spawnKeepAliveThread()` violated this: it passed an anonymous inner `ThreadFactory` to `Executors.newSingleThreadExecutor()`. Per JLS §15.9.5, anonymous inner classes in an instance context **always** get a synthetic `this$0` field pointing to the enclosing instance — even if the body never explicitly references it. This creates a strong path:

```
Cleaner.activeList → PhantomCleanableRef → action lambda → ThreadPoolExecutor
    → ThreadFactory (this$0) → BinaryLogClient → keepAliveThreadExecutor → ASDES (referent)
```

The referent (`AutoShutdownDelegatedExecutorService`) is strongly reachable from its own cleanup action, so it can never become phantom-reachable, the Cleaner never fires, and every `BinaryLogClient` lifecycle leaks ~1.6 MB permanently.

A previous attempt captured the thread name as a local `String` first. Tyler's bytecode review (`javap -p -v`) showed this was a no-op: `newNamedThread` is an instance method, so the compiler still emitted `this$0` in the anonymous class.

## Fix

Replace the anonymous `ThreadFactory` with a `private static final class KeepAliveThreadFactory`. Static nested classes have no `this$0` — confirmed by `javap`: the class has only `delegate` and `threadName` fields.

Also null `keepAliveThreadExecutor` in `terminateKeepAliveThread()` as belt-and-suspenders: this severs the `BLC → executor → referent` strong path directly, so the fix is robust even if a future refactor accidentally reintroduces an outer capture.

## Test plan

- [x] Existing tests pass
- [x] `javap -p -v KeepAliveThreadFactory` confirms no `this$0` field
- [x] Invalidators and invalidation generators [coexist peacefully in the experiment cell](https://app.datadoghq.com/notebook/14396625/exp-cell?fullscreen_widget=o9mzhnwn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)