### PR TITLE
Bump version to 0.30.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.asana</groupId>
     <artifactId>mysql-binlog-connector-java-asana-fork</artifactId>
-    <version>0.30.3</version>
+    <version>0.30.4</version>
 
     <name>mysql-binlog-connector-java</name>
     <description>MySQL Binary Log connector</description>


### PR DESCRIPTION
Re-deploy under 0.30.4 to avoid a CDN cache collision: the `asana-oss-cache.asana.biz` proxy had cached an earlier 0.30.3 artifact (from a previous deploy iteration) with a different checksum, causing Bazel to fail with a checksum mismatch when downloading in CI.

The fix itself (replacing anonymous `ThreadFactory` with `private static final class KeepAliveThreadFactory`) was already merged in #3. This PR is purely the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)